### PR TITLE
ActionParser handles element/attribute identifiers with spaces in selector

### DIFF
--- a/src/ActionParser.php
+++ b/src/ActionParser.php
@@ -11,8 +11,7 @@ use webignition\BasilModels\Action\InteractionAction;
 use webignition\BasilModels\Action\WaitAction;
 use webignition\BasilParser\Exception\EmptyActionException;
 use webignition\BasilParser\Exception\EmptyInputActionValueException;
-use webignition\BasilParser\ValueExtractor\QuotedValueExtractor;
-use webignition\BasilParser\ValueExtractor\VariableValueExtractor;
+use webignition\BasilParser\ValueExtractor\ValueExtractor;
 
 class ActionParser
 {
@@ -30,26 +29,20 @@ class ActionParser
         'wait',
     ];
 
-    private $quotedValueExtractor;
-    private $variableValueExtractor;
     private $identifierExtractor;
+    private $valueExtractor;
 
-    public function __construct(
-        QuotedValueExtractor $quotedValueExtractor,
-        VariableValueExtractor $variableValueExtractor,
-        IdentifierExtractor $identifierExtractor
-    ) {
-        $this->quotedValueExtractor = $quotedValueExtractor;
-        $this->variableValueExtractor = $variableValueExtractor;
+    public function __construct(IdentifierExtractor $identifierExtractor, ValueExtractor $valueExtractor)
+    {
         $this->identifierExtractor = $identifierExtractor;
+        $this->valueExtractor = $valueExtractor;
     }
 
     public static function create(): ActionParser
     {
         return new ActionParser(
-            new QuotedValueExtractor(),
-            new VariableValueExtractor(),
-            IdentifierExtractor::create()
+            IdentifierExtractor::create(),
+            ValueExtractor::create()
         );
     }
 
@@ -125,12 +118,8 @@ class ActionParser
             $valueString = $toKeywordAndValue;
         }
 
-        if ($this->quotedValueExtractor->handles($valueString)) {
-            return $this->quotedValueExtractor->extract($valueString);
-        }
-
-        if ($this->variableValueExtractor->handles($valueString)) {
-            return $this->variableValueExtractor->extract($valueString);
+        if ($this->valueExtractor->handles($valueString)) {
+            return $this->valueExtractor->extract($valueString);
         }
 
         return null;

--- a/src/ValueExtractor/ValueExtractor.php
+++ b/src/ValueExtractor/ValueExtractor.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace webignition\BasilParser\ValueExtractor;
+
+class ValueExtractor
+{
+    private $pageElementIdentifierExtractor;
+    private $quotedValueExtractor;
+    private $variableValueExtractor;
+
+    public function __construct(
+        PageElementIdentifierExtractor $pageElementIdentifierExtractor,
+        QuotedValueExtractor $quotedValueExtractor,
+        VariableValueExtractor $variableValueExtractor
+    ) {
+        $this->pageElementIdentifierExtractor = $pageElementIdentifierExtractor;
+        $this->quotedValueExtractor = $quotedValueExtractor;
+        $this->variableValueExtractor = $variableValueExtractor;
+    }
+
+    public static function create(): ValueExtractor
+    {
+        return new ValueExtractor(
+            new PageElementIdentifierExtractor(),
+            new QuotedValueExtractor(),
+            new VariableValueExtractor()
+        );
+    }
+
+    public function handles(string $string): bool
+    {
+        if ($this->pageElementIdentifierExtractor->handles($string)) {
+            return true;
+        }
+
+        if ($this->quotedValueExtractor->handles($string)) {
+            return true;
+        }
+
+        if ($this->variableValueExtractor->handles($string)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function extract(string $string): string
+    {
+        if ($this->pageElementIdentifierExtractor->handles($string)) {
+            return $this->pageElementIdentifierExtractor->extract($string);
+        }
+
+        if ($this->quotedValueExtractor->handles($string)) {
+            return $this->quotedValueExtractor->extract($string);
+        }
+
+        if ($this->variableValueExtractor->handles($string)) {
+            return $this->variableValueExtractor->extract($string);
+        }
+
+        return '';
+    }
+}

--- a/tests/DataProvider/PageElementIdentifierStringDataProviderTrait.php
+++ b/tests/DataProvider/PageElementIdentifierStringDataProviderTrait.php
@@ -7,103 +7,103 @@ trait PageElementIdentifierStringDataProviderTrait
     public function pageElementIdentifierStringDataProvider(): array
     {
         return [
-            'quoted: assertion: whole-word quoted identifier' => [
+            'page element identifier: whole-word quoted identifier' => [
                 'string' => '$".selector" is "value"',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: assertion: whole-word quoted identifier with positive integer position' => [
+            'page element identifier: whole-word quoted identifier with positive integer position' => [
                 'string' => '$".selector":1 is "value"',
                 'expectedIdentifierString' => '$".selector":1',
             ],
-            'quoted: assertion: whole-word quoted identifier with negative integer position' => [
+            'page element identifier: whole-word quoted identifier with negative integer position' => [
                 'string' => '$".selector":-1 is "value"',
                 'expectedIdentifierString' => '$".selector":-1',
             ],
-            'quoted: assertion: whole-word quoted identifier with first position' => [
+            'page element identifier: whole-word quoted identifier with first position' => [
                 'string' => '$".selector":first is "value"',
                 'expectedIdentifierString' => '$".selector":first',
             ],
-            'quoted: assertion: whole-word quoted identifier with last position' => [
+            'page element identifier: whole-word quoted identifier with last position' => [
                 'string' => '$".selector":last is "value"',
                 'expectedIdentifierString' => '$".selector":last',
             ],
-            'quoted: assertion: whole-word quoted identifier with attribute name' => [
+            'page element identifier: whole-word quoted identifier with attribute name' => [
                 'string' => '$".selector".attribute_name is "value"',
                 'expectedIdentifierString' => '$".selector".attribute_name',
             ],
-            'quoted: assertion: whole-word quoted identifier with positive integer position, attribute name' => [
+            'page element identifier: whole-word quoted identifier with positive integer position, attribute name' => [
                 'string' => '$".selector":1.attribute_name is "value"',
                 'expectedIdentifierString' => '$".selector":1.attribute_name',
             ],
-            'quoted: assertion: whole-word quoted identifier with negative integer position, attribute name' => [
+            'page element identifier: whole-word quoted identifier with negative integer position, attribute name' => [
                 'string' => '$".selector":-1.attribute_name is "value"',
                 'expectedIdentifierString' => '$".selector":-1.attribute_name',
             ],
-            'quoted: assertion: whole-word quoted identifier with first position, attribute name' => [
+            'page element identifier: whole-word quoted identifier with first position, attribute name' => [
                 'string' => '$".selector":first.attribute_name is "value"',
                 'expectedIdentifierString' => '$".selector":first.attribute_name',
             ],
-            'quoted: assertion: whole-word quoted identifier with last position, attribute name' => [
+            'page element identifier: whole-word quoted identifier with last position, attribute name' => [
                 'string' => '$".selector":last.attribute_name is "value"',
                 'expectedIdentifierString' => '$".selector":last.attribute_name',
             ],
-            'quoted: assertion: quoted identifier ending with comparison' => [
+            'page element identifier: quoted identifier ending with comparison' => [
                 'string' => '$".selector is" is "value"',
                 'expectedIdentifierString' => '$".selector is"',
             ],
-            'quoted: assertion: quoted identifier containing comparison and value' => [
+            'page element identifier: quoted identifier containing comparison and value' => [
                 'string' => '$".selector is value" is "value"',
                 'expectedIdentifierString' => '$".selector is value"',
             ],
-            'quoted: assertion: whole-word quoted identifier with encapsulating escaped quotes' => [
+            'page element identifier: whole-word quoted identifier with encapsulating escaped quotes' => [
                 'string' => '$"\".selector\"" is "value"',
                 'expectedIdentifierString' => '$"\".selector\""',
             ],
-            'quoted: assertion: quoted quoted identifier containing escaped quotes' => [
+            'page element identifier: quoted quoted identifier containing escaped quotes' => [
                 'string' => '$".selector \".is\"" is "value"',
                 'expectedIdentifierString' => '$".selector \".is\""',
             ],
-            'quoted: set action arguments: whole-word selector' => [
+            'page element identifier: set action arguments: whole-word selector' => [
                 'string' => '$".selector" to "value"',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: set action arguments: whole-word selector ending with stop word' => [
+            'page element identifier: set action arguments: whole-word selector ending with stop word' => [
                 'string' => '$".selector to " to "value"',
                 'expectedIdentifierString' => '$".selector to "',
             ],
-            'quoted: set action arguments: whole-word containing with stop word' => [
+            'page element identifier: set action arguments: whole-word containing with stop word' => [
                 'string' => '$".selector to value" to "value"',
                 'expectedIdentifierString' => '$".selector to value"',
             ],
-            'quoted: set action arguments: no value following stop word' => [
+            'page element identifier: set action arguments: no value following stop word' => [
                 'string' => '$".selector" to',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'assertion: no value following "is" keyword' => [
+            'page element identifier: no value following "is" keyword' => [
                 'string' => '$".selector" is',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: assertion: no value following "is-not" keyword' => [
+            'page element identifier: no value following "is-not" keyword' => [
                 'string' => '$".selector" is-not',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: assertion: no value following "includes" keyword' => [
+            'page element identifier: no value following "includes" keyword' => [
                 'string' => '$".selector" includes',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: assertion: no value following "excludes" keyword' => [
+            'page element identifier: no value following "excludes" keyword' => [
                 'string' => '$".selector" excludes',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: assertion: no value following "matches" keyword' => [
+            'page element identifier: no value following "matches" keyword' => [
                 'string' => '$".selector" matches',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: whole-word quoted identifier only' => [
+            'page element identifier: whole-word quoted identifier only' => [
                 'string' => '$".selector"',
                 'expectedIdentifierString' => '$".selector"',
             ],
-            'quoted: whole-word quoted identifier with position' => [
+            'page element identifier: whole-word quoted identifier with position' => [
                 'string' => '$".selector":3',
                 'expectedIdentifierString' => '$".selector":3',
             ],

--- a/tests/DataProvider/QuotedValueDataProviderTrait.php
+++ b/tests/DataProvider/QuotedValueDataProviderTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace webignition\BasilParser\Tests\DataProvider;
+
+trait QuotedValueDataProviderTrait
+{
+    public function quotedValueDataProvider(): array
+    {
+        return [
+            'quoted value: empty' => [
+                'valueString' => '',
+                'expectedValue' => '',
+            ],
+            'quoted value: quoted string' => [
+                'valueString' => '"value"',
+                'expectedValue' => '"value"',
+            ],
+            'quoted value: quoted string lacking final quote' => [
+                'valueString' => '"value',
+                'expectedValue' => '"value"',
+            ],
+            'quoted value: quoted string with trailing data' => [
+                'valueString' => '"value" trailing',
+                'expectedValue' => '"value"',
+            ],
+            'quoted value: quoted string with escaped quotes' => [
+                'valueString' => '"\"value\""',
+                'expectedValue' => '"\"value\""',
+            ],
+            'quoted value: quoted string with escaped quotes with trailing data' => [
+                'valueString' => '"\"value\"" trailing',
+                'expectedValue' => '"\"value\""',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/ActionParserTest.php
+++ b/tests/Unit/ActionParserTest.php
@@ -113,13 +113,31 @@ class ActionParserTest extends TestCase
                     '$data.value'
                 ),
             ],
-            'set to variable value, dom identifier value' => [
+            'set to variable value, dom identifier value (1)' => [
                 'actionString' => 'set $".selector1" to $".selector2"',
                 'expectedAction' => new InputAction(
                     'set $".selector1" to $".selector2"',
                     '$".selector1" to $".selector2"',
                     '$".selector1"',
                     '$".selector2"'
+                ),
+            ],
+            'set to variable value, dom identifier value (2)' => [
+                'actionString' => 'set $".selector1":1 to $".selector2":1',
+                'expectedAction' => new InputAction(
+                    'set $".selector1":1 to $".selector2":1',
+                    '$".selector1":1 to $".selector2":1',
+                    '$".selector1":1',
+                    '$".selector2":1'
+                ),
+            ],
+            'set to variable value, dom identifier value (3)' => [
+                'actionString' => 'set $".parent1 .child1" to $".parent2 .child2"',
+                'expectedAction' => new InputAction(
+                    'set $".parent1 .child1" to $".parent2 .child2"',
+                    '$".parent1 .child1" to $".parent2 .child2"',
+                    '$".parent1 .child1"',
+                    '$".parent2 .child2"'
                 ),
             ],
         ];

--- a/tests/Unit/ValueExtractor/QuotedValueExtractorTest.php
+++ b/tests/Unit/ValueExtractor/QuotedValueExtractorTest.php
@@ -2,10 +2,13 @@
 
 namespace webignition\BasilParser\Tests\Unit\ValueExtractor;
 
+use webignition\BasilParser\Tests\DataProvider\QuotedValueDataProviderTrait;
 use webignition\BasilParser\ValueExtractor\QuotedValueExtractor;
 
 class QuotedValueExtractorTest extends \PHPUnit\Framework\TestCase
 {
+    use QuotedValueDataProviderTrait;
+
     /**
      * @var QuotedValueExtractor
      */
@@ -19,42 +22,12 @@ class QuotedValueExtractorTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @dataProvider createFromValueStringDataProvider
+     * @dataProvider quotedValueDataProvider
      */
     public function testExtract(string $valueString, string $expectedValue)
     {
         $value = $this->quotedValueExtractor->extract($valueString);
 
         $this->assertSame($expectedValue, $value);
-    }
-
-    public function createFromValueStringDataProvider(): array
-    {
-        return [
-            'empty' => [
-                'valueString' => '',
-                'expectedValue' => '',
-            ],
-            'quoted string' => [
-                'valueString' => '"value"',
-                'expectedValue' => '"value"',
-            ],
-            'quoted string lacking final quote' => [
-                'valueString' => '"value',
-                'expectedValue' => '"value"',
-            ],
-            'quoted string with trailing data' => [
-                'valueString' => '"value" trailing',
-                'expectedValue' => '"value"',
-            ],
-            'quoted string with escaped quotes' => [
-                'valueString' => '"\"value\""',
-                'expectedValue' => '"\"value\""',
-            ],
-            'quoted string with escaped quotes with trailing data' => [
-                'valueString' => '"\"value\"" trailing',
-                'expectedValue' => '"\"value\""',
-            ],
-        ];
     }
 }

--- a/tests/Unit/ValueExtractor/ValueExtractorTest.php
+++ b/tests/Unit/ValueExtractor/ValueExtractorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace webignition\BasilParser\Tests\Unit\ValueExtractor;
+
+use webignition\BasilParser\Tests\DataProvider\PageElementIdentifierStringDataProviderTrait;
+use webignition\BasilParser\Tests\DataProvider\QuotedValueDataProviderTrait;
+use webignition\BasilParser\Tests\DataProvider\VariableParameterIdentifierStringDataProviderTrait;
+use webignition\BasilParser\ValueExtractor\ValueExtractor;
+
+class ValueExtractorTest extends \PHPUnit\Framework\TestCase
+{
+    use PageElementIdentifierStringDataProviderTrait;
+    use QuotedValueDataProviderTrait;
+    use VariableParameterIdentifierStringDataProviderTrait;
+
+    /**
+     * @var ValueExtractor
+     */
+    private $extractor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extractor = ValueExtractor::create();
+    }
+
+    /**
+     * @dataProvider unhandledStringsDataProvider
+     */
+    public function testHandlesReturnsFalse(string $string)
+    {
+        $this->assertFalse($this->extractor->handles($string));
+    }
+
+    /**
+     * @dataProvider handledStringsDataProvider
+     */
+    public function testHandlesReturnsTrue(string $string)
+    {
+        $this->assertTrue($this->extractor->handles($string));
+    }
+
+    public function handledStringsDataProvider(): array
+    {
+        return [
+            'page element identifier' => [
+                'string' => '$".selector"',
+            ],
+            'quoted value' => [
+                'string' => '"value"',
+            ],
+            'variable value' => [
+                'string' => '$data.key',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider unhandledStringsDataProvider
+     */
+    public function testExtractReturnsEmptyValue(string $string)
+    {
+        $this->assertSame('', $this->extractor->extract($string));
+    }
+
+    public function unhandledStringsDataProvider(): array
+    {
+        return [
+            'empty' => [
+                'string' => '',
+            ],
+            'unquoted literal' => [
+                'string' => 'value',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider pageElementIdentifierStringDataProvider
+     * @dataProvider quotedValueDataProvider
+     * @dataProvider variableParameterIdentifierStringDataProvider
+     */
+    public function testExtractReturnsString(string $string, string $expectedIdentifierString)
+    {
+        $identifierString = $this->extractor->extract($string);
+
+        $this->assertSame($expectedIdentifierString, $identifierString);
+    }
+}


### PR DESCRIPTION
Fixes #37